### PR TITLE
fixing README.md to show buffer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The primary method for sending data. The first argument is a frequency of signal
 ###Events
 &#x20;<a href="#api-infrared-on-data-callback-data-Emitted-when-an-infrared-signal-is-detected" name="api-infrared-on-data-callback-data-Emitted-when-an-infrared-signal-is-detected">#</a> infrared<b>.on</b>( 'data', callback(data) )  
 
-Emitted when an infrared signal is detected. The returned data is an a buffer containing 16-bit words representing the number of microseconds a signal was on and off. For example, a buffer of <0x22,0xc4,0xee,0xd0,0x2,0x58,0xfe,0xc> represents four durations: on for 8900 uS (0x22c4), off for 4400 microseconds (0xeed0 as 2's compliment), on for 600 uS, then off for 320 microseconds.
+Emitted when an infrared signal is detected. The returned data is an a buffer containing 16-bit words representing the number of microseconds a signal was on and off. For example, a buffer of `<0x22,0xc4,0xee,0xd0,0x2,0x58,0xfe,0xc>` represents four durations: on for 8900 uS (0x22c4), off for 4400 microseconds (0xeed0 as 2's compliment), on for 600 uS, then off for 320 microseconds.
 
 You may notice that some durations you received are occasionally off by 50 uS. That's because of the way the receiver logic is implemented. The state of a pin is checked on a 50uS timer and all of those timer ticks are multiplied by 50. If the timer is just a little bit off (or the light is reflected/transformed), it will miss the very start or end of a signal. IR detectors have a high margin of error so this usually has little effect.
 


### PR DESCRIPTION
I fixed a small, confusing problem with GFM hiding what it thought was an HTML node.