### PR TITLE
updated error message to show max signal duration

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ Infrared.prototype.sendRawSignal = function (frequency, signalDurations, callbac
   }
 
   if (signalDurations.length > MAX_SIGNAL_DURATION) {
-    callback && callback(new Error("Invalid buffer length. Must be between 1 and ", MAX_SIGNAL_DURATION));
+    callback && callback(new Error("Invalid buffer length. Must be between 1 and " + MAX_SIGNAL_DURATION));
     return;
   } 
 


### PR DESCRIPTION
It's not currently displaying it, now it does!

```
Error: Invalid buffer length. Must be between 1 and 
    at Error (native)
    at t.sendRawSignal (/tmp/remote-script/node_modules/ir-attx4/index.js:1:2168)
    at b (/tmp/remote-script/node_modules/bluebird/js/main/util.js:1:117)
    at ret [as sendRawSignalAsync] (eval at <anonymous> (/tmp/remote-script/node_modules/bluebird/js/main/promisify.js:1:0), <anonymous>:13:39)
    at send (/tmp/remote-script/index.js:223:34)
    at next (native)
    at i (/tmp/remote-script/node_modules/co/index.js:1:171)
    at process._tickCallback (node.js:366:9)
```